### PR TITLE
Add explicit permissions to CI workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
     - cron: "37 14 * * *" # Run at 7:37 AM Pacific Time (14:37 UTC) every day
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another scheduled run starts while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/src/chatbot/configuration.py
+++ b/src/chatbot/configuration.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass, fields
-from typing import Any, Optional
+from typing import Any
 
 from langgraph.config import get_config
 
@@ -20,7 +20,7 @@ class ChatConfigurable:
     model: str = "anthropic:claude-3-5-sonnet-20240620"
     delay_seconds: int = 3  # For debouncing memory creation
     system_prompt: str = SYSTEM_PROMPT
-    memory_types: Optional[list[dict]] = None
+    memory_types: list[dict] | None = None
     """The memory_types for the memory assistant."""
 
     @classmethod

--- a/src/chatbot/utils.py
+++ b/src/chatbot/utils.py
@@ -1,11 +1,9 @@
 """Define utility functions for your graph."""
 
-from typing import Optional
-
 from langgraph.store.base import Item
 
 
-def format_memories(memories: Optional[list[Item]]) -> str:
+def format_memories(memories: list[Item] | None) -> str:
     """Format the user's memories."""
     if not memories:
         return ""


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` to `unit-tests.yml` and `integration-tests.yml` workflows
- Resolves code scanning alerts [#1](https://github.com/langchain-ai/memory-template/security/code-scanning/1) and [#2](https://github.com/langchain-ai/memory-template/security/code-scanning/2) for `actions/missing-workflow-permissions`
- Follows the principle of least privilege — these workflows only need read access to check out code

## Test plan
- [x] Verify unit tests workflow still passes on PRs and pushes to main
- [x] Verify integration tests workflow still runs on schedule and manual dispatch
